### PR TITLE
Update wifi-mesh-control.service

### DIFF
--- a/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/lib/systemd/system/wifi-mesh-control.service
+++ b/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/lib/systemd/system/wifi-mesh-control.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Meshtastic control of wifi
-After=network.target
+After=meshtasticd.service
+Requires=meshtasticd.service
 
 [Service]
 ExecStart=/usr/local/bin/wifi-mesh-control.sh


### PR DESCRIPTION
Add Requires so wifi-mesh-control wont start until meshtasticd is fully up. Also removed After directive for network.target as meshtasticd service file already has this. Meshtasticd should be up before this service runs.