### PR TITLE
Override for meshtasticd boot order.

### DIFF
--- a/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/etc/systemd/system/meshtasticd.service.d/override.conf
+++ b/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/etc/systemd/system/meshtasticd.service.d/override.conf
@@ -1,3 +1,6 @@
 [Service]
 ExecStartPost=/bin/sh -c 'renice -n -20 -p $(pgrep meshtasticd)'
+[Unit]
+After=rc-local.service
+Wants=rc-local.service
 


### PR DESCRIPTION
meshtasticd api wouldn't respond when started too early.  Thx @noon92 for pushing this across the finish line.